### PR TITLE
feat: remove unstarred repos from Raindrop.io and local archive

### DIFF
--- a/data/starred-repos.json
+++ b/data/starred-repos.json
@@ -1,15 +1,23 @@
 [
   {
-    "full_name": "wojciech-kulik/FlashSpace",
-    "html_url": "https://github.com/wojciech-kulik/FlashSpace",
-    "starred_at": "2025-10-03T16:51:43Z",
-    "description": "FlashSpace is a blazingly fast virtual workspace manager for macOS ⚡",
-    "language": "Swift",
+    "full_name": "FelixKratz/SketchyBar",
+    "html_url": "https://github.com/FelixKratz/SketchyBar",
+    "starred_at": "2025-10-03T17:03:31Z",
+    "description": "A highly customizable macOS status bar replacement",
+    "language": "C",
     "topics": [
-      "apple",
+      "bar",
+      "customization",
+      "darwin",
       "macos",
-      "swift",
-      "window-manager"
+      "ricing",
+      "shell-scripts",
+      "sketchybar",
+      "status",
+      "statusbar",
+      "tiling-window-manager",
+      "ui",
+      "yabai"
     ]
   },
   {

--- a/data/starred-repos.json
+++ b/data/starred-repos.json
@@ -1,23 +1,15 @@
 [
   {
-    "full_name": "FelixKratz/SketchyBar",
-    "html_url": "https://github.com/FelixKratz/SketchyBar",
-    "starred_at": "2025-10-03T17:03:31Z",
-    "description": "A highly customizable macOS status bar replacement",
-    "language": "C",
+    "full_name": "wojciech-kulik/FlashSpace",
+    "html_url": "https://github.com/wojciech-kulik/FlashSpace",
+    "starred_at": "2025-10-03T17:06:13Z",
+    "description": "FlashSpace is a blazingly fast virtual workspace manager for macOS ⚡",
+    "language": "Swift",
     "topics": [
-      "bar",
-      "customization",
-      "darwin",
+      "apple",
       "macos",
-      "ricing",
-      "shell-scripts",
-      "sketchybar",
-      "status",
-      "statusbar",
-      "tiling-window-manager",
-      "ui",
-      "yabai"
+      "swift",
+      "window-manager"
     ]
   },
   {

--- a/src/main.ts
+++ b/src/main.ts
@@ -16,7 +16,7 @@ export const main = async () => {
 
   // Archive starred repos to local JSON file and get current stars
   console.log(new Date(), "Fetching and archiving starred repos...");
-  const starredRepos = await archiveStars(octokit);
+  const { currentStars: starredRepos, unstarredRepos } = await archiveStars(octokit);
   console.log(new Date(), `Found ${starredRepos.length} starred repos!`);
 
   // Convert to the format expected by the original code
@@ -66,5 +66,45 @@ export const main = async () => {
     } else {
       console.log(new Date(), `Skipped chunk (${chunk.length} repos)`);
     }
+  }
+
+  // Delete unstarred repos from Raindrop.io
+  if (unstarredRepos.length > 0) {
+    console.log(new Date(), `Removing ${unstarredRepos.length} unstarred repos from Raindrop...`);
+
+    // Search for raindrops by URL and delete them
+    for (const unstarredRepo of unstarredRepos) {
+      try {
+        // Search for the raindrop by URL in the collection
+        const searchRes = await raindropAxios.get(
+          `/raindrops/${process.env.RAINDROP_COLLECTION_ID}`,
+          {
+            params: {
+              search: unstarredRepo.html_url,
+            },
+          }
+        );
+
+        // Find exact URL match
+        const raindrop = searchRes.data.items?.find(
+          (item: any) => item.link === unstarredRepo.html_url
+        );
+
+        if (raindrop) {
+          // Delete the raindrop
+          await raindropAxios.delete(`/raindrop/${raindrop._id}`);
+          console.log(new Date(), `Deleted: ${unstarredRepo.full_name}`);
+        } else {
+          console.log(new Date(), `Not found in Raindrop: ${unstarredRepo.full_name}`);
+        }
+      } catch (error: any) {
+        console.error(
+          new Date(),
+          `Failed to delete ${unstarredRepo.full_name}: ${error.message}`
+        );
+      }
+    }
+
+    console.log(new Date(), `Finished removing unstarred repos from Raindrop`);
   }
 };


### PR DESCRIPTION
Closes #4

## Changes
- Modified archiveStars() to detect repos that are no longer starred
- Added deletion logic to remove unstarred repos from Raindrop.io
- Updated starred-repos.json to only contain currently starred repos
- Enhanced commit messages to show both additions and deletions

## How It Works
1. Compares current GitHub stars with archived repos
2. Identifies unstarred repos (in archive but not in GitHub)
3. Updates starred-repos.json to reflect current state
4. Searches for and deletes unstarred repos from Raindrop.io

Generated with [Claude Code](https://claude.ai/code)